### PR TITLE
Consent to HTML tags folding in Javadoc comments

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2025 Apr 19
+*syntax.txt*	For Vim version 9.1.  Last change: 2025 Apr 28
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2174,6 +2174,13 @@ default 'foldtext' value; you may opt for showing the contents of a second
 line for any comments written in this way, and showing the contents of a first
 line otherwise, with >
 	:let g:java_foldtext_show_first_or_second_line = 1
+
+HTML tags in Javadoc comments can additionally be folded by following the
+instructions listed under |html-folding| and giving explicit consent with >
+	:let g:java_consent_to_html_syntax_folding = 1
+Do not default to this kind of folding unless ALL start tags and optional end
+tags are balanced in Javadoc comments; otherwise, put up with creating runaway
+folds that break syntax highlighting.
 
 Trailing whitespace characters or a run of space characters before a tab
 character can be marked as an error with >

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2025 Mar 27
+*syntax.txt*	For Vim version 9.1.  Last change: 2025 Apr 19
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1056,8 +1056,12 @@ Variable		Highlight ~
 *c_ansi_typedefs*	 ... but do standard ANSI types
 *c_ansi_constants*	 ... but do standard ANSI constants
 *c_no_utf*		don't highlight \u and \U in strings
-*c_syntax_for_h*	for *.h files use C syntax instead of C++ and use objc
-			syntax instead of objcpp
+*c_syntax_for_h*	use C syntax for *.h files instead of C++/ObjC/ObjC++
+			(NOTE: This variable is deprecated and no longer
+			 necessary, as *.h files now default to C, unless the
+			 file contains C++ or Objective-C syntax. If the
+			 automated detection fails, the default filetype can
+			 be adjusted using `g:filetype_h`.)
 *c_no_if0*		don't highlight "#if 0" blocks as comments
 *c_no_cformat*		don't highlight %-formats in strings
 *c_no_c99*		don't highlight C99 standard items
@@ -1116,8 +1120,11 @@ the C syntax file.  See |c.vim| for all the settings that are available for C.
 
 By setting a variable you can tell Vim to use Ch syntax for *.h files, instead
 of C or C++: >
-	:let ch_syntax_for_h = 1
+	:let g:filetype_h = 'ch'
 
+NOTE: In previous versions of Vim, the following (now-deprecated) variable was
+used, but is no longer the preferred approach: >
+	:let ch_syntax_for_h = 1
 
 CHILL						*chill.vim* *ft-chill-syntax*
 
@@ -2393,11 +2400,16 @@ Comments are also highlighted by default.  You can turn this off by using: >
 
 	:let make_no_comments = 1
 
-Microsoft Makefile handles variable expansion and comments differently
-(backslashes are not used for escape).  If you see any wrong highlights
-because of this, you can try this: >
+There are various Make implementations, which add extensions other than the
+POSIX specification and thus are mutually incompatible.  If the filename is
+BSDmakefile or GNUmakefile, the corresponding implementation is automatically
+determined; otherwise vim tries to detect it by the file contents.  If you see
+any wrong highlights because of this, you can enforce a flavor by setting one
+of the following: >
 
-	:let make_microsoft = 1
+	:let g:make_flavor = 'bsd'  " or
+	:let g:make_flavor = 'gnu'  " or
+	:let g:make_flavor = 'microsoft'
 
 
 MAPLE						*maple.vim* *ft-maple-syntax*
@@ -2450,6 +2462,12 @@ Empty *.m files will automatically be presumed to be Matlab files unless you
 have the following in your .vimrc: >
 
 	let filetype_m = "mma"
+
+MBSYNC					*mbsync.vim* *ft-mbsync-syntax*
+
+The mbsync application uses a configuration file to setup mailboxes names,
+user and password. All files ending with `.mbsyncrc` or with the name
+`isyncrc` will be recognized as mbsync configuration files.
 
 MEDIAWIKI					*ft-mediawiki-syntax*
 

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2025 Mar 26
+" Last Change:		2025 Apr 28
 
 " Please check ":help java.vim" for comments on some of the options
 " available.
@@ -387,15 +387,30 @@ if !exists("g:java_ignore_javadoc") && (s:with_html || s:with_markdown) && g:mai
   " Include HTML syntax coloring for Javadoc comments.
   if s:with_html
     try
+      if exists("g:html_syntax_folding") && !exists("g:java_consent_to_html_syntax_folding")
+	let s:html_syntax_folding_copy = g:html_syntax_folding
+	unlet g:html_syntax_folding
+      endif
+
       syntax include @javaHtml syntax/html.vim
     finally
       unlet! b:current_syntax
+
+      if exists("s:html_syntax_folding_copy")
+	let g:html_syntax_folding = s:html_syntax_folding_copy
+	unlet s:html_syntax_folding_copy
+      endif
     endtry
   endif
 
   " Include Markdown syntax coloring (v7.2.437) for Javadoc comments.
   if s:with_markdown
     try
+      if exists("g:html_syntax_folding") && !exists("g:java_consent_to_html_syntax_folding")
+	let s:html_syntax_folding_copy = g:html_syntax_folding
+	unlet g:html_syntax_folding
+      endif
+
       syntax include @javaMarkdown syntax/markdown.vim
 
       try
@@ -412,6 +427,11 @@ if !exists("g:java_ignore_javadoc") && (s:with_html || s:with_markdown) && g:mai
       let s:no_support = 1
     finally
       unlet! b:current_syntax
+
+      if exists("s:html_syntax_folding_copy")
+	let g:html_syntax_folding = s:html_syntax_folding_copy
+	unlet s:html_syntax_folding_copy
+      endif
 
       if exists("s:no_support")
 	unlet s:no_support

--- a/runtime/syntax/testdir/input/java_comments_html.java
+++ b/runtime/syntax/testdir/input/java_comments_html.java
@@ -1,8 +1,8 @@
 // VIM_TEST_SETUP unlet! g:java_no_tab_space_error g:java_ignore_javadoc
 // VIM_TEST_SETUP unlet! g:java_no_trail_space_error
-// VIM_TEST_SETUP let [g:java_space_errors,g:java_comment_strings]=[1,1]
-// VIM_TEST_SETUP let g:java_ignore_markdown = 1
-
+// VIM_TEST_SETUP unlet! g:java_consent_to_html_syntax_folding
+// VIM_TEST_SETUP let[g:java_space_errors,g:java_comment_strings]=[1,1]
+// VIM_TEST_SETUP let[g:java_ignore_markdown,g:html_syntax_folding]=[1,1]
 
 
 

--- a/runtime/syntax/testdir/input/java_comments_markdown.java
+++ b/runtime/syntax/testdir/input/java_comments_markdown.java
@@ -2,8 +2,8 @@
 // VIM_TEST_SETUP unlet! g:java_no_trail_space_error
 // VIM_TEST_SETUP let[g:java_space_errors,g:java_comment_strings]=[1,1]
 // VIM_TEST_SETUP let[g:java_ignore_html,g:markdown_syntax_conceal]=[1,1]
-
-
+// VIM_TEST_SETUP let g:html_syntax_folding = 1
+// VIM_TEST_SETUP let g:java_consent_to_html_syntax_folding = 1
 
 
 


### PR DESCRIPTION
HTML tags in Javadoc comments can additionally be folded  
after applying

```vim
	let g:html_syntax_folding = 1
	set foldmethod=syntax
```

and giving explicit consent with  

```vim
	let g:java_consent_to_html_syntax_folding = 1
```

Do not default to this kind of folding unless ALL start tags  
and optional end tags are balanced in Javadoc comments;  
otherwise, put up with creating runaway folds that break  
syntax highlighting for the rest of a file.

Resolves #8.
