### PR TITLE
Revamp syntax item generation for type names

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2025 May 21
+*syntax.txt*	For Vim version 9.1.  Last change: 2025 May 30
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2067,13 +2067,8 @@ old way, put the following line into your Vim startup file: >
 All (exported) public types declared in `java.lang` are always automatically
 imported and available as simple names.  To highlight them, use: >
 	:let g:java_highlight_java_lang_ids = 1
-
-You can also highlight types of most standard Java packages if you download
-the javaid.vim script at http://www.fleiner.com/vim/download.html.  If you
-prefer to only highlight types of a certain package, say `java.io`, use the
-following: >
-	:let g:java_highlight_java_io = 1
-Check the javaid.vim file for a list of all the packages that are supported.
+You can also generate syntax items for other public and protected types and
+opt in to highlight some of their names [0].
 
 Headers of indented function declarations can be highlighted (along with parts
 of lambda expressions and method reference expressions), but it depends on how
@@ -2227,6 +2222,7 @@ Note that as soon as the particular preview feature will have been integrated
 into the Java platform, its entry will be removed from the table and related
 optionality will be discontinued.
 
+[0] https://github.com/zzzyxwvut/java-vim/blob/master/tools/javaid/src/javaid/package-info.java
 
 JSON			*json.vim* *ft-json-syntax* *g:vim_json_conceal*
 						*g:vim_json_warnings*

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2025 Apr 28
+*syntax.txt*	For Vim version 9.1.  Last change: 2025 May 21
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -3553,6 +3553,10 @@ variables in your <.vimrc>:
 <   sh: Bourne shell >
 	let g:is_sh	   = 1
 
+Specific shell features are automatically enabled based on the shell detected
+from the shebang line ("#! ...").  For KornShell Vim detects different shell
+features for mksh, ksh88, ksh93, ksh93u, ksh93v, and ksh2020.
+
 If there's no "#! ..." line, and the user hasn't availed himself/herself of a
 default sh.vim syntax setting as just shown, then syntax/sh.vim will assume
 the POSIX shell syntax.  No need to quote RFCs or market penetration
@@ -3996,6 +4000,7 @@ names whose syntax definitions will be included in Typst files. Example: >
 
 VIM			*vim.vim*		*ft-vim-syntax*
 			*g:vimsyn_minlines*	*g:vimsyn_maxlines*
+
 There is a trade-off between more accurate syntax highlighting versus screen
 updating speed.  To improve accuracy, you may wish to increase the
 g:vimsyn_minlines variable.  The g:vimsyn_maxlines variable may be used to
@@ -4019,10 +4024,9 @@ embedded script highlighting they wish to have. >
    g:vimsyn_embed =~ 'r' : support embedded Ruby
    g:vimsyn_embed =~ 't' : support embedded Tcl
 <
-By default, g:vimsyn_embed is a string supporting interpreters that your vim
-itself supports.  Concatenate the indicated characters to support multiple
-types of embedded interpreters (e.g., g:vimsyn_embed = "mp" supports embedded
-mzscheme and embedded perl).
+By default, g:vimsyn_embed is unset, and the Lua and Python script interfaces
+are supported.
+
 						*g:vimsyn_folding*
 Some folding is now supported with when 'foldmethod' is set to "syntax": >
 
@@ -4031,15 +4035,15 @@ Some folding is now supported with when 'foldmethod' is set to "syntax": >
    g:vimsyn_folding =~ 'c' : fold Vim9 classes
    g:vimsyn_folding =~ 'e' : fold Vim9 enums
    g:vimsyn_folding =~ 'f' : fold functions
-   g:vimsyn_folding =~ 'h' : fold heredocs
+   g:vimsyn_folding =~ 'h' : fold let heredocs
    g:vimsyn_folding =~ 'i' : fold Vim9 interfaces
    g:vimsyn_folding =~ 'H' : fold Vim9 legacy headers
-   g:vimsyn_folding =~ 'l' : fold Lua      script
-   g:vimsyn_folding =~ 'm' : fold MzScheme script
-   g:vimsyn_folding =~ 'p' : fold Perl     script
-   g:vimsyn_folding =~ 'P' : fold Python   script
-   g:vimsyn_folding =~ 'r' : fold Ruby     script
-   g:vimsyn_folding =~ 't' : fold Tcl      script
+   g:vimsyn_folding =~ 'l' : fold Lua      heredocs
+   g:vimsyn_folding =~ 'm' : fold MzScheme heredocs
+   g:vimsyn_folding =~ 'p' : fold Perl     heredocs
+   g:vimsyn_folding =~ 'P' : fold Python   heredocs
+   g:vimsyn_folding =~ 'r' : fold Ruby     heredocs
+   g:vimsyn_folding =~ 't' : fold Tcl      heredocs
 <
 
 By default, g:vimsyn_folding is unset.  Concatenate the indicated characters
@@ -5991,6 +5995,12 @@ TabLine		Tab pages line, not active tab page label.
 TabLineFill	Tab pages line, where there are no labels.
 							*hl-TabLineSel*
 TabLineSel	Tab pages line, active tab page label.
+							*hl-TabPanel*
+TabPanel	TabPanel, not active tab page label.
+							*hl-TabPanelFill*
+TabPanelFill	TabPanel, where there are no labels.
+							*hl-TabPanelSel*
+TabPanelSel	TabPanel, active tab page label.
 							*hl-Terminal*
 Terminal	|terminal| window (see |terminal-size-color|).
 							*hl-Title*

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2025 May 30
+*syntax.txt*	For Vim version 9.1.  Last change: 2025 May 31
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2068,7 +2068,7 @@ All (exported) public types declared in `java.lang` are always automatically
 imported and available as simple names.  To highlight them, use: >
 	:let g:java_highlight_java_lang_ids = 1
 You can also generate syntax items for other public and protected types and
-opt in to highlight some of their names [0].
+opt in to highlight some of their names see |java-package-info-url|.
 
 Headers of indented function declarations can be highlighted (along with parts
 of lambda expressions and method reference expressions), but it depends on how
@@ -2221,8 +2221,8 @@ The supported JEP numbers are to be drawn from this table:
 Note that as soon as the particular preview feature will have been integrated
 into the Java platform, its entry will be removed from the table and related
 optionality will be discontinued.
-
-[0] https://github.com/zzzyxwvut/java-vim/blob/master/tools/javaid/src/javaid/package-info.java
+						*java-package-info-url*
+https://github.com/zzzyxwvut/java-vim/blob/42cbd51/tools/javaid/src/javaid/package-info.java
 
 JSON			*json.vim* *ft-json-syntax* *g:vim_json_conceal*
 						*g:vim_json_warnings*

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2025 Apr 28
+" Last Change:		2025 May 30
 
 " Please check ":help java.vim" for comments on some of the options
 " available.
@@ -301,9 +301,7 @@ if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("
   hi def link javaLangObject javaConstant
 endif
 
-if filereadable(expand("<sfile>:p:h") . "/javaid.vim")
-  source <sfile>:p:h/javaid.vim
-endif
+runtime syntax/javaid.vim
 
 if exists("g:java_space_errors")
   if !exists("g:java_no_trail_space_error")

--- a/tools/javaid/AUTHORS
+++ b/tools/javaid/AUTHORS
@@ -1,0 +1,6 @@
+Aliaksei Budavei wrote and currently maintains this generator program.
+
+
+Joris Melchior had written and maintained the *original* generator
+program.  Devin Crain made contributions to it.  Claudio Fleiner took
+over as maintainer of later versions of the program.

--- a/tools/javaid/src/javaid/TypeNameSyntaxItemGenerator.java
+++ b/tools/javaid/src/javaid/TypeNameSyntaxItemGenerator.java
@@ -1,0 +1,502 @@
+package javaid;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Modifier;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A command-line driven generator of optional syntax items for {@code public}
+ * and {@code protected} types.
+ * <p>
+ * As documented in {@code :help java.vim}, the names of {@code public} (and
+ * potentially {@code protected}) type members of the {@link java.lang}
+ * package may be highlighted when the {@code g:java_highlight_java_lang_ids}
+ * variable is defined.  This class provides support for generating similar
+ * syntax items for arbitrary types.
+ *
+ * @see <a href=https://web.archive.org/web/20160608001721/http://www.fleiner.com/vim/Highlight.java><code>Highlight</code></a>,
+ *	a version of the original generator
+ * @since 11 (JDK)
+ */
+final class TypeNameSyntaxItemGenerator
+{
+	private TypeNameSyntaxItemGenerator() { }
+
+	private static String asString(String delimiter,
+						Iterator<String> wordIterator)
+	{
+		final StringJoiner joiner = new StringJoiner(delimiter);
+
+		while (wordIterator.hasNext())
+			joiner.add(wordIterator.next());
+
+		return joiner.toString();
+	}
+
+	private static String asGrownPrefixString(
+			BiConsumer<StringBuilder, StringBuilder> prefixer,
+							String delimiter,
+							String head,
+							String... parts)
+	{
+		if (parts.length < 1)
+			return "";
+
+		final StringBuilder exprBuilder = new StringBuilder(
+							64 * parts.length);
+		final StringBuilder nameBuilder = new StringBuilder(128);
+		nameBuilder.append(head);
+
+		for (String part : parts)
+			prefixer.accept(
+				exprBuilder,
+				nameBuilder.append(delimiter).append(part));
+
+		return exprBuilder.toString();
+	}
+
+	private static String asRunOnTitleString(
+					Map<String, String> titleNames,
+					String name,
+					String[] nameParts)
+	{
+		if (name.isEmpty() || nameParts.length < 1)
+			return "";
+
+		final String knownTitleName = titleNames.get(name);
+
+		if (knownTitleName != null)
+			return knownTitleName;
+
+		final StringBuilder titleBuilder = new StringBuilder(
+						16 * nameParts.length);
+
+		for (String namePart : nameParts) {
+			final int length = titleBuilder.length();
+			titleBuilder.append(namePart)
+				.replace(length,
+					(length + 1),
+					Character.toString(namePart
+							.codePointAt(0))
+						.toUpperCase(Locale.ROOT));
+		}
+
+		final String unknownTitleName = titleBuilder.toString();
+		titleNames.put(name, unknownTitleName);
+		return unknownTitleName;
+	}
+
+	private static void capitaliseParentAndChildNames(
+					Map<String, String> titlePackNames,
+					String packName,
+					String[] packNameParts,
+					String[] parentChildNamePair)
+	{
+		assert (parentChildNamePair.length > 1);
+		parentChildNamePair[0] = asRunOnTitleString(
+			titlePackNames,
+			packName,
+			packNameParts);
+		parentChildNamePair[1] = asRunOnTitleString(
+			titlePackNames,
+			(packNameParts.length > 1)
+				? packName.substring(
+					0,
+					(packName.length() -
+						packNameParts[packNameParts.length - 1]
+							.length() - 1))
+				: "",
+			Arrays.copyOfRange(
+				packNameParts,
+				0,
+				Math.max(0, (packNameParts.length - 1))));
+	}
+
+	private static void generateTypeNameSyntaxItems(
+			PrintWriter writer,
+			Pattern dotParser,
+			Set<String> edgePackNames,
+			Map<String, Map<String, Set<String>>> groupedTypeNames,
+			Map<String, String> modNames)
+	{
+		/* Parts for opt-in guards. */
+		final BiConsumer<StringBuilder, StringBuilder> guardMaker =
+						(headBuilder, tailBuilder) ->
+			headBuilder.append(" || exists(\"g:")
+				.append(tailBuilder)
+				.append("\")");
+		final String prefixName = "java_highlight";
+
+		/* The templets to use for generation. */
+		final String allGuardModStartTemplet =
+			"if exists(\"g:java_highlight_all\")%s" +
+			"%n  \" %s/%s";
+		final String allGuardStartTemplet =
+			"if exists(\"g:java_highlight_all\")%s" +
+			"%n  \" %s";
+		final String allGuardEndTemplet = "%nendif%n%n";
+		final String genericsGuardStartTemplet =
+			"%n%n  if !exists(\"g:java_highlight_generics\")";
+		final String genericsGuardEndTemplet = "%n  endif%n";
+		final String hiGroupsTemplet =
+			"%n  hi def link java%3$s_%1$s java%3$s_%2$s";
+		final String synItemsTemplet =
+			"%n  %5$ssyn keyword java%3$s_%1$s %4$s" +
+			"%n  %5$ssyn cluster javaClasses add=java%3$s_%1$s" +
+			"%n  %5$shi def link java%3$s_%1$s java%3$s_%2$s";
+
+		/* PascalCased package names. */
+		final Map<String, String> titlePackNames = new HashMap<>();
+
+		for (Map.Entry<String, Map<String, Set<String>>> pack :
+						groupedTypeNames.entrySet()) {
+			final boolean isParentPack = (pack.getKey()
+							.endsWith("\u0020"));
+			final String packName = (isParentPack)
+				? pack.getKey().stripTrailing()
+				: pack.getKey();
+			final String modName = modNames.get(packName);
+			final String[] packNameParts = dotParser.split(
+								packName);
+			final String[] packNamePair = {"", ""};
+			capitaliseParentAndChildNames(titlePackNames,
+							packName,
+							packNameParts,
+							packNamePair);
+
+			if (modName != null) {
+				modNames.remove(packName);
+				writer.format(allGuardModStartTemplet,
+						asGrownPrefixString(
+							guardMaker,
+							"_",
+							prefixName,
+							packNameParts),
+						modName,
+						packName);
+			} else {
+				writer.format(allGuardStartTemplet,
+						asGrownPrefixString(
+							guardMaker,
+							"_",
+							prefixName,
+							packNameParts),
+						packName);
+			}
+
+			if (isParentPack) {
+				for (String groupName :
+						pack.getValue().keySet())
+					writer.format(hiGroupsTemplet,
+							packNamePair[0],
+							packNamePair[1],
+							groupName);
+			} else {
+				for (Map.Entry<String, Set<String>> group :
+						pack.getValue().entrySet()) {
+					final String classNames = asString(
+						"\u0020",
+						group.getValue().iterator());
+					final String groupOtherName =
+							group.getKey();
+					final String groupName = ("_C".equals(
+							groupOtherName))
+						? "C"
+						: ("_I".equals(groupOtherName))
+							? "I"
+							: groupOtherName;
+
+					if (groupOtherName.startsWith("_")) {
+						writer.format(genericsGuardStartTemplet)
+							.format(synItemsTemplet,
+								packNamePair[0],
+								packNamePair[1],
+								groupName,
+								classNames,
+								"\u0020\u0020")
+							.format(genericsGuardEndTemplet);
+					} else if (!group.getValue().isEmpty()) {
+						writer.format(synItemsTemplet,
+								packNamePair[0],
+								packNamePair[1],
+								groupName,
+								classNames,
+								"");
+					} else if (edgePackNames.contains(
+								packName)) {
+						/*
+						 * Cf. generic-only interface
+						 * members of java.base/
+						 * sun.reflect.generics.visitor.
+						 */
+						writer.format(hiGroupsTemplet,
+								packNamePair[0],
+								packNamePair[1],
+								groupName);
+					}
+				}
+			}
+
+			writer.format(allGuardEndTemplet).flush();
+		}
+	}
+
+	private static void linkSubpackages(
+			Pattern dotParser,
+			Set<String> edgePackNames,
+			Map<String, Map<String, Set<String>>> groupedTypeNames)
+	{
+		final Map<String, Map<String, Set<String>>> typeNamesCopy =
+						TypeNameSyntaxItemGenerator
+				.<Map<String, Set<String>>>sortedMap();
+		typeNamesCopy.putAll(groupedTypeNames);
+
+		for (Map.Entry<String, Map<String, Set<String>>> pack :
+						typeNamesCopy.entrySet()) {
+			final String packName = pack.getKey();
+			final Map<String, Set<String>> linkGroupNames =
+						TypeNameSyntaxItemGenerator
+					.<Set<String>>sortedMap();
+
+			/*
+			 * Mask "_[CI]"s as "[CI]"s and duplicate the latter
+			 * when found for subpackages.
+			 */
+			for (String groupName : pack.getValue().keySet())
+				linkGroupNames.put(("_C".equals(groupName))
+					? "C"
+					: ("_I".equals(groupName))
+						? "I"
+						: groupName,
+					Set.of());
+
+			final Set<String> parentPackNames = new HashSet<>();
+			final StringBuilder packNameBuilder =
+					new StringBuilder(packName.length());
+			final String[] packNameParts = dotParser.split(
+								packName);
+
+			for (String part : Arrays.copyOfRange(
+					packNameParts,
+					0,
+					Math.max(0, (packNameParts.length - 1)))) {
+				final String parentPackName =
+						packNameBuilder.append(part)
+								.toString();
+				final Map<String, Set<String>> packGroupNames =
+						groupedTypeNames.get(
+							parentPackName);
+
+				if (packGroupNames == null) {
+					groupedTypeNames.computeIfAbsent(
+							parentPackName
+								.concat("\u0020"),
+							k -> TypeNameSyntaxItemGenerator
+								.<Set<String>>sortedMap())
+						.putAll(linkGroupNames);
+				} else {
+					for (String linkGroupName :
+							linkGroupNames.keySet())
+						packGroupNames.merge(
+							linkGroupName,
+							Set.of(),
+							(oldValue, newValue) ->
+								oldValue);
+				}
+
+				parentPackNames.add(parentPackName);
+				packNameBuilder.append('.');
+			}
+
+			parentPackNames.remove(packName);
+			edgePackNames.addAll(parentPackNames);
+		}
+	}
+
+	private static String group(Class<?> type)
+	{
+		return (type.getTypeParameters().length > 0)
+			? (type.isInterface())
+				? "_I"
+				: "_C"
+			: (type.isInterface())
+				? "I"
+				: (RuntimeException.class.isAssignableFrom(type))
+					? "R"
+					: (Exception.class.isAssignableFrom(type))
+						? "X"
+						: (Error.class.isAssignableFrom(type))
+							? "E"
+							: "C";
+	}
+
+	private static String parseInTypeName(Pattern parser, String candidate)
+	{
+		final Matcher matcher = parser.matcher(candidate);
+		final String typeName;
+		return (matcher.find() && (typeName = matcher.group(1)) != null)
+			? typeName.replace('/', '.')
+			: candidate;
+	}
+
+	private static Class<?> findPublicOrProtectedType(String typeName,
+							ClassLoader loader)
+	{
+		final Class<?> type;
+
+		try {
+			type = Class.forName(typeName, false, loader);
+		} catch (final ReflectiveOperationException e) {
+			e.printStackTrace();
+			return null;
+		}
+
+		Class<?> member = type;
+
+		do {
+			/*
+			 * Reject non-API types and nested API types that are
+			 * members of non-API types.
+			 */
+			if (!(((Modifier.PUBLIC | Modifier.PROTECTED) &
+						member.getModifiers()) != 0))
+				return null;
+		} while ((member = member.getEnclosingClass()) != null);
+
+		return type;
+	}
+
+	private static void findAndGroupTypeNames(
+			BufferedReader reader,
+			ClassLoader loader,
+			Map<String, Map<String, Set<String>>> groupedTypeNames,
+			Map<String, String> modNames) throws IOException
+	{
+		/* The ‘parser’ of file- and type-names of named packages. */
+		final Pattern typeNameParser = Pattern.compile(
+			"^.*?((?:\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*?[/.](?!class$))+" +
+			"\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)");
+		String candidate;
+
+		while ((candidate = reader.readLine()) != null) {
+			final Class<?> type = findPublicOrProtectedType(
+				parseInTypeName(typeNameParser, candidate),
+				loader);
+
+			if (type == null)
+				continue;
+
+			final String groupName = group(type);
+			final String packName = type.getPackageName();
+			final String modName = type.getModule().getName();
+			modNames.put(packName,
+					(modName == null)
+						? "[unnamed]"
+						: modName);
+			groupedTypeNames.computeIfAbsent(
+					packName,
+					k -> TypeNameSyntaxItemGenerator
+						.<Set<String>>sortedMap())
+				.computeIfAbsent(
+					groupName,
+					k -> TypeNameSyntaxItemGenerator
+						.<String>sortedSet())
+				.add(type.getSimpleName());
+		}
+	}
+
+	private static <E> Set<E> sortedSet()
+	{
+		return new TreeSet<>();
+	}
+
+	private static <E> Map<String, E> sortedMap()
+	{
+		return new TreeMap<>();
+	}
+
+	/**
+	 * Attempts to generate optional syntax items for a list of requested
+	 * types whose runtime instances are discoverable.  Each listed type
+	 * must have a {@link Class#getCanonicalName canonical name} that is
+	 * written out on a separate line either in fully-qualified form or as
+	 * a relative path to its class file.
+	 *
+	 * @param args optional command-line arguments: the input pathname to
+	 *	a file with a list of requested types, one type per line, to
+	 *	generate syntax items for; followed by the output pathname to
+	 *	a file where to store generated syntax items; otherwise, the
+	 *	standard input and/or output streams are used
+	 * @throws IOException if an I/O error occurs
+	 * @see Class#forName(String, boolean, ClassLoader)
+	 */
+	public static void main(String[] args) throws IOException
+	{
+		/* The class loader to use for loading requested types. */
+		final ClassLoader loader = TypeNameSyntaxItemGenerator.class
+			.getClassLoader();
+
+		/* The ‘parser’ of package-names. */
+		final Pattern dotParser = Pattern.compile("\\.");
+
+		/* Scratch structures. */
+		final Set<String> edgePackNames = new HashSet<>();
+		final Map<String, String> modNames = new HashMap<>();
+		final Map<String, Map<String, Set<String>>> groupedTypeNames =
+						TypeNameSyntaxItemGenerator
+				.<Map<String, Set<String>>>sortedMap();
+
+		try (Reader ir = (args.length > 0 && !("-".equals(args[0])))
+					? new FileReader(args[0],
+						Charset.defaultCharset())
+					: new InputStreamReader(System.in) {
+						@Override public void close() { }
+					};
+				BufferedReader reader = new BufferedReader(ir)) {
+			findAndGroupTypeNames(reader,
+						loader,
+						groupedTypeNames,
+						modNames);
+		}
+
+		/* Ensure that there is a ":hi-link" for every subpackage. */
+		linkSubpackages(dotParser, edgePackNames, groupedTypeNames);
+
+		try (Writer ow = (args.length > 1)
+					? new FileWriter(args[1],
+						Charset.defaultCharset())
+					: new OutputStreamWriter(System.out) {
+						@Override public void close() { }
+					};
+				Writer bw = new BufferedWriter(ow);
+				PrintWriter writer = new PrintWriter(bw, false)) {
+			generateTypeNameSyntaxItems(writer,
+						dotParser,
+						edgePackNames,
+						groupedTypeNames,
+						modNames);
+		}
+	}
+}

--- a/tools/javaid/src/javaid/package-info.java
+++ b/tools/javaid/src/javaid/package-info.java
@@ -1,0 +1,26 @@
+/**
+ * Provides syntax item generation for type names.
+ * <p>
+ * In order to enable the recognition of selected type names in Vim, proceed
+ * as follows:<ol>
+ * <li>Apply a name filter to an arbitrary class-file list.
+ * <li>Pass the filtered list to {@link TypeNameSyntaxItemGenerator} and let
+ *	it generate a new syntax file; name the new file {@code javaid.vim}.
+ * <li>Copy that file to one of {@code runtime/syntax} directories.
+ * <li>In Vim, define opt-in variables that guard desired syntax items, e.g.
+ *	{@code g:java_highlight_all}, and re-link some highlighting groups,
+ *	e.g. {@code javaC_}, {@code javaE_}, {@code javaI_}, {@code javaR_},
+ *	{@code javaX_} (respectively grouping names for classes etc., errors,
+ *	interfaces etc., runtime exceptions, and checked exceptions).
+ * </ol>
+ * <p><b>Generation examples</b>
+ * <pre>{@code
+ * echo javaid/TypeNameSyntaxItemGenerator.class | java javaid.TypeNameSyntaxItemGenerator
+ * jar tf /tmp/acme.jar | grep '\.class$' | java -cp .:/tmp/acme.jar javaid.TypeNameSyntaxItemGenerator
+ * jimage list $JDK_ROOT_DIR/lib/modules | grep -F java/io | java javaid.TypeNameSyntaxItemGenerator
+ * java javaid.TypeNameSyntaxItemGenerator [< ]/tmp/classlist [> ]~/.vim/syntax/javaid.vim
+ * }</pre>
+ *
+ * @since 11 (JDK)
+ */
+package javaid;

--- a/tools/javaid/testdir/11_java_SPARSE_PREFIX.vim
+++ b/tools/javaid/testdir/11_java_SPARSE_PREFIX.vim
@@ -1,0 +1,154 @@
+if exists("g:java_highlight_all") || exists("g:java_highlight_java")
+  " java
+  hi def link javaC_Java javaC_
+  hi def link javaI_Java javaI_
+  hi def link javaX_Java javaX_
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_awt")
+  " java.awt
+  hi def link javaC_JavaAwt javaC_Java
+  hi def link javaI_JavaAwt javaI_Java
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_awt") || exists("g:java_highlight_java_awt_dnd")
+  " java.awt.dnd
+  hi def link javaI_JavaAwtDnd javaI_JavaAwt
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_awt") || exists("g:java_highlight_java_awt_dnd") || exists("g:java_highlight_java_awt_dnd_peer")
+  " java.desktop/java.awt.dnd.peer
+  syn keyword javaI_JavaAwtDndPeer DragSourceContextPeer DropTargetContextPeer DropTargetPeer
+  syn cluster javaClasses add=javaI_JavaAwtDndPeer
+  hi def link javaI_JavaAwtDndPeer javaI_JavaAwtDnd
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_awt") || exists("g:java_highlight_java_awt_im")
+  " java.awt.im
+  hi def link javaI_JavaAwtIm javaI_JavaAwt
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_awt") || exists("g:java_highlight_java_awt_im") || exists("g:java_highlight_java_awt_im_spi")
+  " java.desktop/java.awt.im.spi
+  syn keyword javaI_JavaAwtImSpi InputMethod InputMethodContext InputMethodDescriptor
+  syn cluster javaClasses add=javaI_JavaAwtImSpi
+  hi def link javaI_JavaAwtImSpi javaI_JavaAwtIm
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_awt") || exists("g:java_highlight_java_awt_image")
+  " java.awt.image
+  hi def link javaC_JavaAwtImage javaC_JavaAwt
+  hi def link javaI_JavaAwtImage javaI_JavaAwt
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_awt") || exists("g:java_highlight_java_awt_image") || exists("g:java_highlight_java_awt_image_renderable")
+  " java.desktop/java.awt.image.renderable
+  syn keyword javaC_JavaAwtImageRenderable ParameterBlock RenderContext RenderableImageOp RenderableImageProducer
+  syn cluster javaClasses add=javaC_JavaAwtImageRenderable
+  hi def link javaC_JavaAwtImageRenderable javaC_JavaAwtImage
+  syn keyword javaI_JavaAwtImageRenderable ContextualRenderedImageFactory RenderableImage RenderedImageFactory
+  syn cluster javaClasses add=javaI_JavaAwtImageRenderable
+  hi def link javaI_JavaAwtImageRenderable javaI_JavaAwtImage
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_nio")
+  " java.nio
+  hi def link javaC_JavaNio javaC_Java
+  hi def link javaI_JavaNio javaI_Java
+  hi def link javaX_JavaNio javaX_Java
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_nio") || exists("g:java_highlight_java_nio_channels")
+  " java.nio.channels
+  hi def link javaC_JavaNioChannels javaC_JavaNio
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_nio") || exists("g:java_highlight_java_nio_channels") || exists("g:java_highlight_java_nio_channels_spi")
+  " java.base/java.nio.channels.spi
+  syn keyword javaC_JavaNioChannelsSpi AbstractInterruptibleChannel AbstractSelectableChannel AbstractSelectionKey AbstractSelector AsynchronousChannelProvider SelectorProvider
+  syn cluster javaClasses add=javaC_JavaNioChannelsSpi
+  hi def link javaC_JavaNioChannelsSpi javaC_JavaNioChannels
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_nio") || exists("g:java_highlight_java_nio_charset")
+  " java.nio.charset
+  hi def link javaC_JavaNioCharset javaC_JavaNio
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_nio") || exists("g:java_highlight_java_nio_charset") || exists("g:java_highlight_java_nio_charset_spi")
+  " java.base/java.nio.charset.spi
+  syn keyword javaC_JavaNioCharsetSpi CharsetProvider
+  syn cluster javaClasses add=javaC_JavaNioCharsetSpi
+  hi def link javaC_JavaNioCharsetSpi javaC_JavaNioCharset
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_nio") || exists("g:java_highlight_java_nio_file")
+  " java.nio.file
+  hi def link javaC_JavaNioFile javaC_JavaNio
+  hi def link javaI_JavaNioFile javaI_JavaNio
+  hi def link javaX_JavaNioFile javaX_JavaNio
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_nio") || exists("g:java_highlight_java_nio_file") || exists("g:java_highlight_java_nio_file_attribute")
+  " java.base/java.nio.file.attribute
+  syn keyword javaC_JavaNioFileAttribute AclEntry AclEntryFlag AclEntryPermission AclEntryType Builder FileTime PosixFilePermission PosixFilePermissions UserPrincipalLookupService
+  syn cluster javaClasses add=javaC_JavaNioFileAttribute
+  hi def link javaC_JavaNioFileAttribute javaC_JavaNioFile
+  syn keyword javaI_JavaNioFileAttribute AclFileAttributeView AttributeView BasicFileAttributeView BasicFileAttributes DosFileAttributeView DosFileAttributes FileAttributeView FileOwnerAttributeView FileStoreAttributeView GroupPrincipal PosixFileAttributeView PosixFileAttributes UserDefinedFileAttributeView UserPrincipal
+  syn cluster javaClasses add=javaI_JavaNioFileAttribute
+  hi def link javaI_JavaNioFileAttribute javaI_JavaNioFile
+  syn keyword javaX_JavaNioFileAttribute UserPrincipalNotFoundException
+  syn cluster javaClasses add=javaX_JavaNioFileAttribute
+  hi def link javaX_JavaNioFileAttribute javaX_JavaNioFile
+
+  if !exists("g:java_highlight_generics")
+    syn keyword javaI_JavaNioFileAttribute FileAttribute
+    syn cluster javaClasses add=javaI_JavaNioFileAttribute
+    hi def link javaI_JavaNioFileAttribute javaI_JavaNioFile
+  endif
+
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_nio") || exists("g:java_highlight_java_nio_file") || exists("g:java_highlight_java_nio_file_spi")
+  " java.base/java.nio.file.spi
+  syn keyword javaC_JavaNioFileSpi FileSystemProvider FileTypeDetector
+  syn cluster javaClasses add=javaC_JavaNioFileSpi
+  hi def link javaC_JavaNioFileSpi javaC_JavaNioFile
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_util")
+  " java.util
+  hi def link javaC_JavaUtil javaC_Java
+  hi def link javaI_JavaUtil javaI_Java
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_util") || exists("g:java_highlight_java_util_concurrent")
+  " java.util.concurrent
+  hi def link javaC_JavaUtilConcurrent javaC_JavaUtil
+  hi def link javaI_JavaUtilConcurrent javaI_JavaUtil
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_util") || exists("g:java_highlight_java_util_concurrent") || exists("g:java_highlight_java_util_concurrent_atomic")
+  " java.base/java.util.concurrent.atomic
+  syn keyword javaC_JavaUtilConcurrentAtomic AtomicBoolean AtomicInteger AtomicIntegerArray AtomicLong AtomicLongArray DoubleAccumulator DoubleAdder LongAccumulator LongAdder
+  syn cluster javaClasses add=javaC_JavaUtilConcurrentAtomic
+  hi def link javaC_JavaUtilConcurrentAtomic javaC_JavaUtilConcurrent
+
+  if !exists("g:java_highlight_generics")
+    syn keyword javaC_JavaUtilConcurrentAtomic AtomicIntegerFieldUpdater AtomicLongFieldUpdater AtomicMarkableReference AtomicReference AtomicReferenceArray AtomicReferenceFieldUpdater AtomicStampedReference
+    syn cluster javaClasses add=javaC_JavaUtilConcurrentAtomic
+    hi def link javaC_JavaUtilConcurrentAtomic javaC_JavaUtilConcurrent
+  endif
+
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_util") || exists("g:java_highlight_java_util_concurrent") || exists("g:java_highlight_java_util_concurrent_locks")
+  " java.base/java.util.concurrent.locks
+  syn keyword javaC_JavaUtilConcurrentLocks AbstractOwnableSynchronizer AbstractQueuedLongSynchronizer AbstractQueuedSynchronizer ConditionObject LockSupport ReadLock ReentrantLock ReentrantReadWriteLock StampedLock WriteLock
+  syn cluster javaClasses add=javaC_JavaUtilConcurrentLocks
+  hi def link javaC_JavaUtilConcurrentLocks javaC_JavaUtilConcurrent
+  syn keyword javaI_JavaUtilConcurrentLocks Condition Lock ReadWriteLock
+  syn cluster javaClasses add=javaI_JavaUtilConcurrentLocks
+  hi def link javaI_JavaUtilConcurrentLocks javaI_JavaUtilConcurrent
+endif
+

--- a/tools/javaid/testdir/11_java_lang.vim
+++ b/tools/javaid/testdir/11_java_lang.vim
@@ -1,0 +1,42 @@
+if exists("g:java_highlight_all") || exists("g:java_highlight_java")
+  " java
+  hi def link javaC_Java javaC_
+  hi def link javaE_Java javaE_
+  hi def link javaI_Java javaI_
+  hi def link javaR_Java javaR_
+  hi def link javaX_Java javaX_
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_lang")
+  " java.base/java.lang
+  syn keyword javaC_JavaLang Boolean Byte Character ClassLoader Compiler Controller Double Float Integer Level LoggerFinder Long Math Module ModuleLayer Number Object Option Package Process ProcessBuilder Redirect Runtime RuntimePermission SecurityManager Short StackTraceElement StackWalker State StrictMath String StringBuffer StringBuilder Subset System Thread ThreadGroup Throwable Type UnicodeBlock UnicodeScript Version Void
+  syn cluster javaClasses add=javaC_JavaLang
+  hi def link javaC_JavaLang javaC_Java
+  syn keyword javaE_JavaLang AbstractMethodError AssertionError BootstrapMethodError ClassCircularityError ClassFormatError Error ExceptionInInitializerError IllegalAccessError IncompatibleClassChangeError InstantiationError InternalError LinkageError NoClassDefFoundError NoSuchFieldError NoSuchMethodError OutOfMemoryError StackOverflowError ThreadDeath UnknownError UnsatisfiedLinkError UnsupportedClassVersionError VerifyError VirtualMachineError
+  syn cluster javaClasses add=javaE_JavaLang
+  hi def link javaE_JavaLang javaE_Java
+  syn keyword javaI_JavaLang Appendable AutoCloseable CharSequence Cloneable Deprecated FunctionalInterface Info Logger Override ProcessHandle Readable Runnable SafeVarargs StackFrame SuppressWarnings UncaughtExceptionHandler
+  syn cluster javaClasses add=javaI_JavaLang
+  hi def link javaI_JavaLang javaI_Java
+  syn keyword javaR_JavaLang ArithmeticException ArrayIndexOutOfBoundsException ArrayStoreException ClassCastException EnumConstantNotPresentException IllegalArgumentException IllegalCallerException IllegalMonitorStateException IllegalStateException IllegalThreadStateException IndexOutOfBoundsException LayerInstantiationException NegativeArraySizeException NullPointerException NumberFormatException RuntimeException SecurityException StringIndexOutOfBoundsException TypeNotPresentException UnsupportedOperationException
+  syn cluster javaClasses add=javaR_JavaLang
+  hi def link javaR_JavaLang javaR_Java
+  syn keyword javaX_JavaLang ClassNotFoundException CloneNotSupportedException Exception IllegalAccessException InstantiationException InterruptedException NoSuchFieldException NoSuchMethodException ReflectiveOperationException
+  syn cluster javaClasses add=javaX_JavaLang
+  hi def link javaX_JavaLang javaX_Java
+
+  if !exists("g:java_highlight_generics")
+    syn keyword javaC_JavaLang Class ClassValue Enum InheritableThreadLocal ThreadLocal
+    syn cluster javaClasses add=javaC_JavaLang
+    hi def link javaC_JavaLang javaC_Java
+  endif
+
+
+  if !exists("g:java_highlight_generics")
+    syn keyword javaI_JavaLang Comparable Iterable
+    syn cluster javaClasses add=javaI_JavaLang
+    hi def link javaI_JavaLang javaI_Java
+  endif
+
+endif
+

--- a/tools/javaid/testdir/11_sun_management_PREFIX_MULTI_MODULE_WITH_GENERICS.vim
+++ b/tools/javaid/testdir/11_sun_management_PREFIX_MULTI_MODULE_WITH_GENERICS.vim
@@ -1,0 +1,78 @@
+if exists("g:java_highlight_all") || exists("g:java_highlight_sun")
+  " sun
+  hi def link javaC_Sun javaC_
+  hi def link javaI_Sun javaI_
+  hi def link javaR_Sun javaR_
+  hi def link javaX_Sun javaX_
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_sun") || exists("g:java_highlight_sun_management")
+  " java.management/sun.management
+  syn keyword javaC_SunManagement BaseOperatingSystemImpl CompilerThreadStat GarbageCollectorImpl HotspotInternal LazyCompositeData LockInfoCompositeData ManagementFactoryHelper MappedMXBeanType MemoryNotifInfoCompositeData MemoryUsageCompositeData MethodInfo MonitorInfoCompositeData NotificationEmitterSupport Sensor StackTraceElementCompositeData ThreadImpl ThreadInfoCompositeData Util
+  syn cluster javaClasses add=javaC_SunManagement
+  hi def link javaC_SunManagement javaC_Sun
+  syn keyword javaI_SunManagement HotspotClassLoadingMBean HotspotCompilationMBean HotspotInternalMBean HotspotMemoryMBean HotspotRuntimeMBean HotspotThreadMBean VMManagement
+  syn cluster javaClasses add=javaI_SunManagement
+  hi def link javaI_SunManagement javaI_Sun
+  hi def link javaR_SunManagement javaR_Sun
+  hi def link javaX_SunManagement javaX_Sun
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_sun") || exists("g:java_highlight_sun_management") || exists("g:java_highlight_sun_management_counter")
+  " java.management/sun.management.counter
+  syn keyword javaC_SunManagementCounter AbstractCounter Units Variability
+  syn cluster javaClasses add=javaC_SunManagementCounter
+  hi def link javaC_SunManagementCounter javaC_SunManagement
+  syn keyword javaI_SunManagementCounter ByteArrayCounter Counter LongArrayCounter LongCounter StringCounter
+  syn cluster javaClasses add=javaI_SunManagementCounter
+  hi def link javaI_SunManagementCounter javaI_SunManagement
+  hi def link javaR_SunManagementCounter javaR_SunManagement
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_sun") || exists("g:java_highlight_sun_management") || exists("g:java_highlight_sun_management_counter") || exists("g:java_highlight_sun_management_counter_perf")
+  " java.management/sun.management.counter.perf
+  syn keyword javaC_SunManagementCounterPerf PerfByteArrayCounter PerfInstrumentation PerfLongArrayCounter PerfLongCounter PerfStringCounter
+  syn cluster javaClasses add=javaC_SunManagementCounterPerf
+  hi def link javaC_SunManagementCounterPerf javaC_SunManagementCounter
+  syn keyword javaR_SunManagementCounterPerf InstrumentationException
+  syn cluster javaClasses add=javaR_SunManagementCounterPerf
+  hi def link javaR_SunManagementCounterPerf javaR_SunManagementCounter
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_sun") || exists("g:java_highlight_sun_management") || exists("g:java_highlight_sun_management_jdp")
+  " jdk.management.agent/sun.management.jdp
+  syn keyword javaC_SunManagementJdp JdpBroadcaster JdpController JdpGenericPacket JdpJmxPacket JdpPacketReader JdpPacketWriter
+  syn cluster javaClasses add=javaC_SunManagementJdp
+  hi def link javaC_SunManagementJdp javaC_SunManagement
+  syn keyword javaI_SunManagementJdp JdpPacket
+  syn cluster javaClasses add=javaI_SunManagementJdp
+  hi def link javaI_SunManagementJdp javaI_SunManagement
+  syn keyword javaX_SunManagementJdp JdpException
+  syn cluster javaClasses add=javaX_SunManagementJdp
+  hi def link javaX_SunManagementJdp javaX_SunManagement
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_sun") || exists("g:java_highlight_sun_management") || exists("g:java_highlight_sun_management_jmxremote")
+  " jdk.management.agent/sun.management.jmxremote
+  syn keyword javaC_SunManagementJmxremote ConnectorBootstrap LocalRMIServerSocketFactory SingleEntryRegistry
+  syn cluster javaClasses add=javaC_SunManagementJmxremote
+  hi def link javaC_SunManagementJmxremote javaC_SunManagement
+  syn keyword javaI_SunManagementJmxremote DefaultValues PropertyNames
+  syn cluster javaClasses add=javaI_SunManagementJmxremote
+  hi def link javaI_SunManagementJmxremote javaI_SunManagement
+endif
+
+if exists("g:java_highlight_all") || exists("g:java_highlight_sun") || exists("g:java_highlight_sun_management") || exists("g:java_highlight_sun_management_spi")
+  " java.management/sun.management.spi
+  syn keyword javaC_SunManagementSpi PlatformMBeanProvider
+  syn cluster javaClasses add=javaC_SunManagementSpi
+  hi def link javaC_SunManagementSpi javaC_SunManagement
+
+  if !exists("g:java_highlight_generics")
+    syn keyword javaI_SunManagementSpi PlatformComponent
+    syn cluster javaClasses add=javaI_SunManagementSpi
+    hi def link javaI_SunManagementSpi javaI_SunManagement
+  endif
+
+endif
+

--- a/tools/javaid/testdir/runner.sh
+++ b/tools/javaid/testdir/runner.sh
@@ -1,0 +1,26 @@
+#!/bin/sh -e
+
+: "${JDK_11_ROOT_DIR:?}"
+cd "$(dirname "$0")"/..
+
+classlist=testdir/filtered_modules_classlist
+trap 'rm -f "$classlist"' EXIT HUP INT QUIT TERM
+jimage list "$JDK_11_ROOT_DIR/lib/modules" | \
+	grep -E '^\s*(java/|sun/management/)' > "$classlist"
+javac -d bin --release 11 -Xdiags:verbose -Xlint \
+	src/javaid/TypeNameSyntaxItemGenerator.java
+
+grep -E '^\s*java/lang/[^/]+\.class$' "$classlist" | \
+	java -cp bin javaid.TypeNameSyntaxItemGenerator \
+	- testdir/11_java_lang.vim
+grep -E '^\s*java(/[^/]+){4,}.+\.class$' "$classlist" | \
+	java -cp bin javaid.TypeNameSyntaxItemGenerator \
+	- testdir/11_java_SPARSE_PREFIX.vim
+grep -E '^\s*sun/management/.+\.class$' "$classlist" | \
+	java -cp bin javaid.TypeNameSyntaxItemGenerator \
+	- testdir/11_sun_management_PREFIX_MULTI_MODULE_WITH_GENERICS.vim
+grep -E '^\s*module-info\.class$' "$classlist" | \
+	java -ea:javaid -cp bin javaid.TypeNameSyntaxItemGenerator \
+	> testdir/11_GI_GO.vim
+
+git diff --exit-code -- testdir/


### PR DESCRIPTION
Simple type names of standard packages may be highlighted  
whenever an auxiliary, auto-generated script `javaid.vim` is  
copied to one of `runtime/syntax` directories and relevant  
opt-in variables are defined (see `:help java.vim`).

As the Java Platform continues to evolve, new core types are  
introduced and, at times, old core types are retired.  The  
latest uploaded `javaid.vim` is as up to date as JDK 5 is.  
The good news is that a modern version of the file can still  
be generated by the same Java program and its source file is  
available.  The bad news is that that program only accepts  
JAR files as input for processing and associating qualifying  
class files with their runtime types; this effectively rules  
out standard packages for selection since `rt.jar` has been  
superseded by a `modules` image in JDK 9.  There is no need  
to obtain the list of filenames from a JAR file by reading  
it with that program since all such filenames must still be  
resolved at runtime; the `jar` utility provides a contents  
listing operation `t` for own archives, the `jimage` utility  
provides a contents listing operation `list` for own images.  
Another relic of the past present in the generated output  
made by the program is its reliance on using script-defined  
`:JavaHiLink` commands, oblivious of the fact that their  
definition in `syntax/java.vim` was to be elsewhere removed  
in `v7.4.2297~1`.

An ALTERNATIVE GENERATOR PROGRAM, written from scratch, is  
therefore submitted.  It targets JDK 11+ and continues to  
shape its output format after the fashion of the original  
generator program and DIFFERS FROM THAT PROGRAM AS FOLLOWS.

The original generator and the offered alternative generator  
are collecting different sets of type names.  The former is  
collecting names of any-access classes, enumerations, and  
records, quietly omitting interfaces and annotations with  
`NullPointerException`s (`c=c.getSuperclass()`).  The latter  
is collecting names of classes and interfaces (and all their  
specialisation kinds), top or nested, that admit `public` or  
`protected` access, provided that each and every enclosing  
type, if any, also admits `public` or `protected` access,  
i.e. API names.

Package naming doesn't concern the alternative generator.

The alternative generator accommodates parameterised and  
generic type-name highlighting in case such recognition is  
requested ([`019a89f`](https://github.com/zzzyxwvut/java-vim/commit/019a89fb84115d518252322095158a81087eeff7)).  (Note that some generated syntax  
items for non-unique simple type names may require manual  
revision to follow, especially when one item purports to  
match a generic simple type name and the other one doesn't.  
Cf. attempting to match `Builder<T>` _or_ `Builder`.)

Syntax groups are no longer hand picked for the `@javaTop`  
cluster in `syntax/java.vim` ([`587556d`](https://github.com/zzzyxwvut/java-vim/commit/587556d459c24bf195fdb4732867008971abb2ec)); the alternative  
generator follows suit.

With the alternative generator, initial name filtering can  
be arranged before name collection, e.g. `grep -F foo/bar`;  
thus, ALL class files from a JAR file should now only be  
listed when it is desired to highlight ALL their qualifying  
type names.  Less work during generation, less work for  
a Vim instance sourcing smaller `javaid.vim` scripts.  The  
obvious drawback is that users will have to generate their  
own `javaid.vim` versions.

The `javaid.TypeNameSyntaxItemGenerator` program expects  
a list of types discoverable at runtime and written one per  
line for its input: either relative paths to class files  
‘within an archive’, say `java/lang/Object.class`, or their  
fully-qualified form, say `java.lang.Object`.  For example,

```sh
echo javaid/TypeNameSyntaxItemGenerator.class | java javaid.TypeNameSyntaxItemGenerator
jar tf /tmp/acme.jar | grep '\.class$' | java -cp .:/tmp/acme.jar javaid.TypeNameSyntaxItemGenerator
jimage list $JDK_ROOT_DIR/lib/modules | grep -F java/io | java javaid.TypeNameSyntaxItemGenerator
java javaid.TypeNameSyntaxItemGenerator [< ]/tmp/classlist [> ]~/.vim/syntax/javaid.vim
```

Also, generalise the sourcing of `javaid.vim` for Java  
buffers.

References:
https://openjdk.org/jeps/220 (Modular Run-Time Images)
https://web.archive.org/web/20051124124303/http://www.fleiner.com/vim/syntax_60/javaid.vim
https://web.archive.org/web/20240625125527/http://www.fleiner.com/vim/syntax_60/javaid.vim
https://web.archive.org/web/20160608001721/http://www.fleiner.com/vim/Highlight.java
