### PR TITLE
Fold adjacent `import` declarations

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2025 Oct 04
+*syntax.txt*	For Vim version 9.1.  Last change: 2025 Oct 07
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -6024,6 +6024,11 @@ PmenuMatch	Popup menu: Matched text in normal item. Applied in
 							*hl-PmenuMatchSel*
 PmenuMatchSel	Popup menu: Matched text in selected item. Applied in
 		combination with |hl-PmenuSel|.
+							*hl-PmenuBorder*
+PmenuBorder	Popup menu: Border characters.
+		Linked to |hl-Pmenu| by default.
+							*hl-PmenuShadow*
+PmenuShadow	Popup menu: Used for shadow.
 							*hl-ComplMatchIns*
 ComplMatchIns	Matched text of the currently inserted completion.
 							*hl-PreInsert*
@@ -6092,6 +6097,16 @@ TabPanelSel	TabPanel, active tab page label.
 Terminal	|terminal| window (see |terminal-size-color|).
 							*hl-Title*
 Title		Titles for output from ":set all", ":autocmd" etc.
+							*hl-TitleBar*
+TitleBar	Title bar for the active Gui's window.
+		This feature is supported only in the MS-Windows GUI.
+		See |gui-w32-title-bar| for details
+		Only the `guibg` and `guifg` highlight arguments are effective.
+							*hl-TitleBarNC*
+TitleBarNC	Title bar for inactive Gui's window.
+		This feature is supported only in the MS-Windows GUI.
+		See |gui-w32-title-bar| for details
+		Only the `guibg` and `guifg` highlight arguments are effective.
 							*hl-Visual*
 Visual		Visual mode selection.
 							*hl-VisualNOS*
@@ -6492,10 +6507,10 @@ faster.  To see slowness switch on some features that usually interfere, such
 as 'relativenumber' and |folding|.
 
 Note: This is only available when compiled with the |+profile| feature.
-You many need to build Vim with "huge" features.
+You may need to build Vim with "huge" features.
 
-To find out what patterns are consuming most time, get an overview with this
-sequence: >
+To find out what patterns are consuming the most time, get an overview with
+this sequence: >
 	:syntime on
 	[ redraw the text at least once with CTRL-L ]
 	:syntime report

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2025 Oct 07
+*syntax.txt*	For Vim version 9.1.  Last change: 2025 Oct 08
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2214,14 +2214,17 @@ Note that these three variables are maintained in the HTML syntax file.
 Numbers and strings can be recognized in non-Javadoc comments with >
 	:let g:java_comment_strings = 1
 
-When 'foldmethod' is set to "syntax", blocks of code and multi-line comments
-will be folded.  No text is usually written in the first line of a multi-line
-comment, making folded contents of Javadoc comments less informative with the
-default 'foldtext' value; you may opt for showing the contents of a second
-line for any comments written in this way, and showing the contents of a first
-line otherwise, with >
+When 'foldmethod' is set to "syntax", multi-line blocks of code ("b"), plain
+comments ("c"), Javadoc comments ("d"), and adjacent "import" declarations
+("i") will be folded by default.  Syntax items of any supported kind will
+remain NOT foldable when its abbreviated name is delisted with >
+	:let g:java_ignore_folding = "bcdi"
+No text is usually written in the first line of a multi-line comment, making
+folded contents of Javadoc comments less informative with the default
+'foldtext' value; you may opt for showing the contents of a second line for
+any comments written in this way, and showing the contents of a first line
+otherwise, with >
 	:let g:java_foldtext_show_first_or_second_line = 1
-
 HTML tags in Javadoc comments can additionally be folded by following the
 instructions listed under |html-folding| and giving explicit consent with >
 	:let g:java_consent_to_html_syntax_folding = 1

--- a/runtime/syntax/testdir/input/java_enfoldment.java
+++ b/runtime/syntax/testdir/input/java_enfoldment.java
@@ -1,9 +1,29 @@
-// VIM_TEST_SETUP setlocal foldenable foldcolumn=2 foldmethod=syntax
+// VIM_TEST_SETUP setlocal fen fdc=2 fdl=8 fdm=syntax
 // VIM_TEST_SETUP let g:java_foldtext_show_first_or_second_line = 1
+// VIM_TEST_SETUP let g:java_highlight_java_lang = 1
+// VIM_TEST_SETUP let g:java_ignore_folding = "x"
 // VIM_TEST_SETUP let g:java_lookbehind_byte_counts = {'javaBlock': -1}
+
+
+
+
+
 // VIM_TEST_SETUP highlight link javaBlockOtherStart Structure
 // VIM_TEST_SETUP highlight link javaBlockStart Todo
 
+
+
+/***/  import java.lang.Comparable;	/*
+import java.lang.Object;
+import java.lang.String;
+*/
+import java.lang.String;
+
+import java.lang.Comparable;	/***/
+import java.lang.Object;	// //
+import java.lang.String;	/***/
+
+import java.util.function.Function;
 	@SuppressWarnings({
 	"""
 	bespoke
@@ -24,11 +44,14 @@
 """
 })
 class FoldingTests {
-	interface Foldenable
+	interface Foldable
 	{
 	}
 
 	static {
+		String import⁠$ = """
+import java.lang.String;
+""";
 		new Object() {
 			{
 				{
@@ -58,12 +81,12 @@ out: {
 }
 	}
 /*\\\*/	{
-		(new java.util.function.Function<Object, Object>() {
+		(new Function<Object, Object>() {
 			/**
 			 * {@inheritDoc} */
 			public Object apply(Object o) { return o; };
 		}).apply(
-		(new java.util.function.Function<Object, Object>() {
+		(new Function<Object, Object>() {
 			/** {@inheritDoc}
 			 */
 			public Object apply(Object o) { return o; };
@@ -118,5 +141,5 @@ out: {
 // {
 // }
 
-/* 122|..........................................................................................*/ interface Foldenable {
+/* 120|..........................................................................................*/ interface Foldable {
 }

--- a/runtime/syntax/testdir/input/java_unfoldment.java
+++ b/runtime/syntax/testdir/input/java_unfoldment.java
@@ -1,9 +1,29 @@
-// VIM_TEST_SETUP setlocal nofoldenable
-// VIM_TEST_SETUP let g:java_mark_braces_in_parens_as_errors = 1
+// VIM_TEST_SETUP setlocal fen fdc=2 fdl=8 fdm=syntax
+// VIM_TEST_SETUP let g:java_highlight_java_lang = 1
+// VIM_TEST_SETUP let g:java_ignore_folding = "bcdi"
 // VIM_TEST_SETUP let g:java_lookbehind_byte_counts = {'javaBlock': -1}
+// VIM_TEST_SETUP let g:java_mark_braces_in_parens_as_errors = 1
+
+
+
+
+
 // VIM_TEST_SETUP highlight link javaBlockOtherStart Structure
 // VIM_TEST_SETUP highlight link javaBlockStart Todo
 
+
+
+/***/  import java.lang.Comparable;	/*
+import java.lang.Object;
+import java.lang.String;
+*/
+import java.lang.String;
+
+import java.lang.Comparable;	/***/
+import java.lang.Object;	// //
+import java.lang.String;	/***/
+
+import java.util.function.Function;
 	@SuppressWarnings({
 	"""
 	bespoke
@@ -24,11 +44,14 @@
 """
 })
 class UnfoldingTests {
-	interface Unfoldenable
+	interface Unfoldable
 	{
 	}
 
 	static {
+		String import⁠$ = """
+import java.lang.String;
+""";
 		new Object() {
 			{
 				{
@@ -58,12 +81,12 @@ out: {
 }
 	}
 /*\\\*/	{
-		(new java.util.function.Function<Object, Object>() {
+		(new Function<Object, Object>() {
 			/**
 			 * {@inheritDoc} */
 			public Object apply(Object o) { return o; };
 		}).apply(
-		(new java.util.function.Function<Object, Object>() {
+		(new Function<Object, Object>() {
 			/** {@inheritDoc}
 			 */
 			public Object apply(Object o) { return o; };
@@ -118,5 +141,5 @@ out: {
 // {
 // }
 
-/* 122|........................................................................................*/ interface Unfoldenable {
+/* 120|........................................................................................*/ interface Unfoldable {
 }


### PR DESCRIPTION
Also, distinguish (by abbreviating their names) and manage  
foldable kinds of syntax items: blocks of code (`b`), plain  
comments (`c`), Javadoc comments (`d`), adjacent `import`  
declarations (`i`).  Fold all qualifying items by default;  
otherwise, do not fold items of explicitly delisted kinds.  
For example,

```vim
	let g:java_ignore_folding = "bcdi"
```

Resolves #12.
